### PR TITLE
bhard/add_crawl_bug

### DIFF
--- a/app/db_api.py
+++ b/app/db_api.py
@@ -156,25 +156,22 @@ def db_init_ache(project, crawl):
     relevant_data_uri = os.path.join(CRAWLS_PATH, crawl.name, 'data/data_monitor/relevantpages.csv')
     relevant_data = DataSource(name=key + '-relevantpages',
                                data_uri=relevant_data_uri,
-                               project_id=project.id,
-                               crawl=crawl)
+                               project_id=project.id)
 
     frontier_data_uri = os.path.join(CRAWLS_PATH, crawl.name, 'data/data_monitor/frontierpages.csv')
     frontier_data = DataSource(name=key + '-frontierpages',
                                data_uri=frontier_data_uri,
-                               project_id=project.id,
-                               crawl=crawl)
+                               project_id=project.id)
 
     harvest_data_uri = os.path.join(CRAWLS_PATH, crawl.name, 'data/data_monitor/harvestinfo.csv')
     harvest_data = DataSource(name=key + '-harvestinfo',
                               data_uri=harvest_data_uri,
-                              project_id=project.id,
-                              crawl=crawl)
+                              project_id=project.id)
 
-    crawl.data_source.append(crawled_data)
-    crawl.data_source.append(relevant_data)
-    crawl.data_source.append(frontier_data)
-    crawl.data_source.append(harvest_data)
+    crawl.data_sources.append(crawled_data)
+    crawl.data_sources.append(relevant_data)
+    crawl.data_sources.append(frontier_data)
+    crawl.data_sources.append(harvest_data)
 
     db.session.add(crawled_data)
     db.session.add(relevant_data)


### PR DESCRIPTION
closes #103 

So this one a bit confusing. I'm confused as to why the filenames for the sample database crawls, data, etc. have a relative path, while every time I add them through the application they have an absolute path. Which is it supposed to be? From the way this function is written its going to set the filenames to absolute paths. 

Also, crawl was not a field in the data_sources table and I think that's what was causing the error. Description for data sources is just left blank, but I could change it to the crawl description.

What do you think @chdoig ?